### PR TITLE
Add gunicorn Procfile for Railway deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn wsgi:app

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ requests==2.31.0
 Werkzeug==2.3.7
 alembic==1.12.1
 psycopg2-binary==2.9.9
+
+gunicorn==21.2.0


### PR DESCRIPTION
## Summary
- add gunicorn dependency
- define Procfile web command for wsgi app

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement gunicorn==21.2.0)*
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897ab83dd38832c9c31e83f43d44421