### PR TITLE
Run migrations on startup and ensure states table

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --bind 0.0.0.0:$PORT wsgi:app
+web: alembic upgrade head && gunicorn --bind 0.0.0.0:$PORT wsgi:app

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s %(asctime)s %(name)s %(message)s
+

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,5 +1,15 @@
 """WSGI entry point for Railway deployment."""
-from app import create_app
+from sqlalchemy import inspect
+
+from app import create_app, db
 
 # Expose application instance for WSGI servers
 app = create_app()
+
+# Verify critical tables exist so migrations aren't skipped
+with app.app_context():
+    inspector = inspect(db.engine)
+    if not inspector.has_table("states"):
+        app.logger.error(
+            "Required table 'states' not found. Run database migrations before starting."
+        )


### PR DESCRIPTION
## Summary
- run Alembic migrations automatically before starting the server
- add startup check logging an error when required tables are missing
- include Alembic configuration for CLI usage

## Testing
- `alembic upgrade head`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689840b66c7c832cb11670b85d677792