### PR TITLE
Add student file browser linked from success page

### DIFF
--- a/templates/student_files.html
+++ b/templates/student_files.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Student Files</title>
+    <meta charset="utf-8">
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        table { border-collapse: collapse; width: 100%; margin-bottom: 20px; }
+        th, td { border: 1px solid #ddd; padding: 8px; }
+        th { background-color: #f2f2f2; }
+    </style>
+</head>
+<body>
+    <h1>Student Files</h1>
+    {% if uploaded is not none %}
+    <p>{{ uploaded }} file(s) uploaded to filestore.</p>
+    {% endif %}
+    <form method="post">
+        {% for student in students %}
+        <h3>{{ student.fullname }}</h3>
+        {% if student.files %}
+        <table>
+            <tr><th>Select</th><th>Filename</th></tr>
+            {% for file in student.files %}
+            <tr>
+                <td><input type="checkbox" name="files" value="{{ file.url }}"></td>
+                <td><a href="{{ file.url }}" target="_blank">{{ file.filename }}</a></td>
+            </tr>
+            {% endfor %}
+        </table>
+        {% else %}
+        <p>No files found.</p>
+        {% endif %}
+        {% endfor %}
+        <button type="submit">Upload Selected</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Include Moodle token in file URLs so an administrator can download student uploads
- Link filenames in the student file manager and preserve original names when saving

## Testing
- `pytest` *(fails: tests/test_deep_link.py::test_deep_link_return_posts_response, tests/test_deep_link.py::test_deep_link_accepts_post, tests/test_deep_link_return_accepts_get)*

------
https://chatgpt.com/codex/tasks/task_e_689917a37efc832c8aa8b03e6d25b582