### PR TITLE
Improve LTI session handling for file routes

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -30,3 +30,7 @@ class Config:
     # Nonce/state expiry windows
     STATE_EXPIRATION = timedelta(minutes=5)
     NONCE_EXPIRATION = timedelta(minutes=5)
+
+    # Ensure session cookies work within an iframe when launched from an LMS
+    SESSION_COOKIE_SAMESITE = "None"
+    SESSION_COOKIE_SECURE = True

--- a/tests/test_files_blueprint.py
+++ b/tests/test_files_blueprint.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app import create_app, db
+
+
+@pytest.fixture()
+def app():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_require_session_redirects_to_login(client):
+    resp = client.get("/files/file_browser")
+    assert resp.status_code == 302
+    assert "/lti/login" in resp.headers.get("Location", "")
+
+
+def test_require_session_returns_html_error(client):
+    resp = client.get("/files/get_user_files/1", headers={"Accept": "application/json"})
+    assert resp.status_code == 401
+    assert "text/html" in resp.headers.get("Content-Type", "")
+    assert b"Unauthorized" in resp.data


### PR DESCRIPTION
## Summary
- Redirect missing LTI sessions to the login flow and display an HTML error for JSON clients
- Configure session cookies for LMS iframes
- Add tests covering file session requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68992b46b8dc832c9d44ee4e9383d954