### PR TITLE
Improve LTI session handling for file routes

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -30,3 +30,7 @@ class Config:
     # Nonce/state expiry windows
     STATE_EXPIRATION = timedelta(minutes=5)
     NONCE_EXPIRATION = timedelta(minutes=5)
+
+    # Ensure session cookies work within an iframe when launched from an LMS
+    SESSION_COOKIE_SAMESITE = "None"
+    SESSION_COOKIE_SECURE = True

--- a/app/files/blueprint.py
+++ b/app/files/blueprint.py
@@ -8,9 +8,12 @@ from flask import (
     session,
     send_from_directory,
     render_template_string,
+    redirect,
+    url_for,
 )
 from werkzeug.utils import secure_filename
 import requests
+from ..models import Platform
 
 files_bp = Blueprint("files", __name__)
 
@@ -130,8 +133,31 @@ def _validate_file(file_storage) -> tuple[bool, str]:
 
 @files_bp.before_request
 def _require_session():
-    if not _ensure_lti_session():
-        return jsonify({"error": "unauthorized"}), 401
+    if _ensure_lti_session():
+        return None
+
+    # API clients that explicitly request JSON get an HTML error page
+    # instead of a JSON payload so the response is more user-friendly.
+    if request.headers.get("Accept") == "application/json":
+        html = """
+        <h1>Unauthorized</h1>
+        <p>No active LTI session. Please launch this tool from your LMS.</p>
+        """
+        return render_template_string(html), 401
+
+    # Otherwise redirect to the LTI login endpoint to re-establish session
+    # before hitting the requested URL. Include the platform issuer so the
+    # login handler knows which registration to use.
+    platform = Platform.query.first()
+    if platform:
+        return redirect(
+            url_for(
+                "lti.login",
+                target_link_uri=request.url,
+                iss=platform.issuer,
+            )
+        )
+    return redirect(url_for("lti.login", target_link_uri=request.url))
 
 
 @files_bp.route("/get_user_files/<int:user_id>")

--- a/tests/test_files_blueprint.py
+++ b/tests/test_files_blueprint.py
@@ -1,0 +1,50 @@
+import os
+import sys
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app import create_app, db
+from app.models import Platform
+
+
+@pytest.fixture()
+def app():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        db.session.add(
+            Platform(
+                issuer="https://lms.example.com",
+                client_id="client_id",
+                auth_login_url="https://lms.example.com/login",
+                auth_token_url="https://lms.example.com/token",
+                jwks_uri="https://lms.example.com/jwks",
+            )
+        )
+        db.session.commit()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_require_session_redirects_to_login(client):
+    resp = client.get("/files/file_browser")
+    assert resp.status_code == 302
+    location = resp.headers.get("Location", "")
+    assert "/lti/login" in location
+    qs = parse_qs(urlparse(location).query)
+    assert qs.get("iss") == ["https://lms.example.com"]
+
+
+def test_require_session_returns_html_error(client):
+    resp = client.get("/files/get_user_files/1", headers={"Accept": "application/json"})
+    assert resp.status_code == 401
+    assert "text/html" in resp.headers.get("Content-Type", "")
+    assert b"Unauthorized" in resp.data


### PR DESCRIPTION
## Summary
- Redirect missing LTI sessions to the login flow with the platform issuer and display an HTML error for JSON clients
- Configure session cookies for LMS iframes
- Add tests covering file session requirements

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68992b46b8dc832c9d44ee4e9383d954