### PR TITLE
Handle optional login_hint in LTI login

### DIFF
--- a/app/lti/launch.py
+++ b/app/lti/launch.py
@@ -89,10 +89,11 @@ def login():
         "response_mode": "form_post",
         "client_id": platform.client_id,
         "redirect_uri": url_for("lti.lti_launch", _external=True),
-        "login_hint": request.values.get("login_hint", ""),
         "state": state_val,
         "nonce": nonce_val,
     }
+    if login_hint:
+        params["login_hint"] = login_hint
     
     # Optional lti_message_hint support
     if request.values.get("lti_message_hint"):

--- a/tests/test_lti_login.py
+++ b/tests/test_lti_login.py
@@ -1,0 +1,50 @@
+import os
+import sys
+from urllib.parse import urlparse, parse_qs
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app import create_app, db
+from app.models import Platform
+
+
+@pytest.fixture()
+def app():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_login_omits_login_hint_when_absent(client, app):
+    with app.app_context():
+        platform = Platform(
+            issuer="https://lms.example.com",
+            client_id="client123",
+            auth_login_url="https://lms.example.com/auth",
+            auth_token_url="https://lms.example.com/token",
+            jwks_uri="https://lms.example.com/jwks",
+        )
+        db.session.add(platform)
+        db.session.commit()
+
+    res = client.get(
+        "/lti/login",
+        query_string={
+            "iss": "https://lms.example.com",
+            "target_link_uri": "https://tool.example.com/launch",
+            "client_id": "client123",
+        },
+    )
+    assert res.status_code == 302
+    qs = urlparse(res.headers["Location"]).query
+    params = parse_qs(qs)
+    assert "login_hint" not in params


### PR DESCRIPTION
## Summary
- Only include `login_hint` in OIDC params when provided
- Add unit test ensuring redirect omits `login_hint` when absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68993386788c832ca4826afcefa245ab