### PR TITLE
Redirect resource link launches to original target

### DIFF
--- a/app/lti/launch.py
+++ b/app/lti/launch.py
@@ -254,15 +254,17 @@ def lti_launch():
     elif message_type == "LtiResourceLinkRequest":
         # Regular resource link launch
         current_app.logger.info("Resource link request received")
-    
-    # Log successful launch
-    current_app.logger.info(f"Successful LTI launch for user: {data.get('sub')} from platform: {iss}")
-    
-    # Instead of redirecting back to launch endpoint, redirect to success page
-    if message_type == "LtiResourceLinkRequest":
-        # For regular resource link requests, redirect to success landing page
-        return redirect(url_for("lti.lti_success"))
-    
+        current_app.logger.info(
+            f"Successful LTI launch for user: {data.get('sub')} from platform: {iss}"
+        )
+        # Redirect to the originally requested resource if available
+        return redirect(redirect_after or url_for("lti.lti_success"))
+
+    # Log successful launch for non-resource link requests
+    current_app.logger.info(
+        f"Successful LTI launch for user: {data.get('sub')} from platform: {iss}"
+    )
+
     # For other message types, return JSON
     return jsonify({
         "launch": "success",
@@ -271,7 +273,7 @@ def lti_launch():
         "platform": iss,
         "user_name": data.get("name"),
         "context": data.get("https://purl.imsglobal.org/spec/lti/claim/context", {}).get("title"),
-        "return_url": data.get("https://purl.imsglobal.org/spec/lti/claim/launch_presentation", {}).get("return_url")
+        "return_url": data.get("https://purl.imsglobal.org/spec/lti/claim/launch_presentation", {}).get("return_url"),
     })
 
 

--- a/tests/test_resource_link_redirect.py
+++ b/tests/test_resource_link_redirect.py
@@ -1,0 +1,72 @@
+import jwt
+from datetime import datetime, timedelta
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app import create_app, db
+from app.models import Platform, State, Nonce
+
+
+@pytest.fixture()
+def app():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_resource_link_launch_redirects_to_original_target(client, app, monkeypatch):
+    with app.app_context():
+        platform = Platform(
+            issuer="https://lms.example.com",
+            client_id="client123",
+            auth_login_url="https://lms.example.com/auth",
+            auth_token_url="https://lms.example.com/token",
+            jwks_uri="https://lms.example.com/jwks",
+        )
+        db.session.add(platform)
+        db.session.add(
+            Nonce(value="nonce123", expires_at=datetime.utcnow() + timedelta(minutes=5))
+        )
+        db.session.add(
+            State(
+                value="state123",
+                redirect_after="/resource",
+                expires_at=datetime.utcnow() + timedelta(minutes=5),
+            )
+        )
+        db.session.commit()
+
+    payload = {
+        "iss": "https://lms.example.com",
+        "aud": "client123",
+        "nonce": "nonce123",
+        "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiResourceLinkRequest",
+    }
+
+    class DummyJWKClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_signing_key_from_jwt(self, token):
+            class Key:
+                key = "secret"
+
+            return Key()
+
+    monkeypatch.setattr(jwt, "PyJWKClient", lambda url: DummyJWKClient())
+    monkeypatch.setattr(jwt, "decode", lambda *args, **kwargs: payload)
+
+    res = client.post("/lti/launch", data={"id_token": "token", "state": "state123"})
+    assert res.status_code == 302
+    assert res.headers["Location"].endswith("/resource")


### PR DESCRIPTION
## Summary
- Redirect `LtiResourceLinkRequest` launches to the target URL stored during login
- Add regression test for resource link launch redirection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689977372a28832caa0185f6e10490de