### PR TITLE
Support LTIK and cookieless access

### DIFF
--- a/tests/test_resource_link_redirect.py
+++ b/tests/test_resource_link_redirect.py
@@ -1,5 +1,6 @@
 import jwt
 from datetime import datetime, timedelta
+from urllib.parse import parse_qs, urlparse
 import os
 import sys
 import pytest
@@ -108,4 +109,6 @@ def test_resource_link_launch_avoids_login_redirect(client, app, monkeypatch):
 
     res = client.post("/lti/launch", data={"id_token": "token", "state": "state123"})
     assert res.status_code == 302
-    assert res.headers["Location"].endswith("/lti/success")
+    loc = res.headers["Location"]
+    assert urlparse(loc).path == "/lti/success"
+    assert "ltik" in parse_qs(urlparse(loc).query)


### PR DESCRIPTION
## Summary
- issue a short-lived LTIK during LTI launch and forward it to the success page
- accept LTIK on file routes to hydrate session when cookies are blocked
- adjust tests for LTIK-aware success redirect

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899836aea28832c8f41448c34ab19c1