### PR TITLE
Enable selecting and uploading files from file browser

### DIFF
--- a/tests/test_assignment_files.py
+++ b/tests/test_assignment_files.py
@@ -72,12 +72,15 @@ def test_get_assignment_files_returns_files(app, monkeypatch):
             }
         return None
 
-    with app.app_context():
-        monkeypatch.setattr("app.files.blueprint.moodle_api_call", fake_call)
-        files = get_assignment_files(42, 99)
-        assert files == [
-            {"filename": "a.txt", "fileurl": "url", "filesize": 1, "source": "Assignment: Essay"}
-        ]
+        with app.app_context():
+            monkeypatch.setattr("app.files.blueprint.moodle_api_call", fake_call)
+            files = get_assignment_files(42, 99)
+            assert len(files) == 1
+            file = files[0]
+            assert file["filename"] == "a.txt"
+            assert file["fileurl"] == "url"
+            assert file["filesize"] == 1
+            assert file["source"] == "Assignment: Essay"
 
 
 def test_get_assignment_files_skips_draft(app, monkeypatch):


### PR DESCRIPTION
## Summary
- Allow `/files/file_browser` to accept POST requests and save selected URLs to the configured upload directory
- Add checkboxes and upload button for Moodle files in file browser UI
- Log submission status errors when gathering assignment files and adjust tests for new behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a4a53ada0832ca8919f03867b4088