### PR TITLE
Track admin-uploaded files and verify listing

### DIFF
--- a/app/files/blueprint.py
+++ b/app/files/blueprint.py
@@ -1746,8 +1746,18 @@ def file_browser():
                     resp = requests.get(url, timeout=10)
                     resp.raise_for_status()
                     filename = url.rsplit("/", 1)[-1].split("?")[0]
-                    with open(os.path.join(upload_dir, filename), "wb") as handle:
+                    path = os.path.join(upload_dir, filename)
+                    with open(path, "wb") as handle:
                         handle.write(resp.content)
+                    file_id = uuid.uuid4().hex
+                    info = {
+                        "id": file_id,
+                        "filename": filename,
+                        "path": path,
+                        "owner": selected_user,
+                    }
+                    save_file_metadata(info)
+                    local_files.append(info)
                     uploaded += 1
                 except Exception as err:  # pragma: no cover - network errors
                     current_app.logger.error(f"Failed to download {url}: {err}")

--- a/tests/test_files_blueprint.py
+++ b/tests/test_files_blueprint.py
@@ -110,7 +110,9 @@ def test_admin_select_user_lists_files(client):
 
     resp = client.get("/files/file_browser?user_id=10")
     assert resp.status_code == 200
-    assert b"sample.txt" in resp.data
+    body = resp.data.decode()
+    assert "Uploaded to SV Service" in body
+    assert "sample.txt" in body.split("Uploaded to SV Service", 1)[1]
 
 
 def test_admin_sees_user_uploads(client):
@@ -134,7 +136,9 @@ def test_admin_sees_user_uploads(client):
 
     resp = client.get("/files/file_browser?user_id=10")
     assert resp.status_code == 200
-    assert b"hello.txt" in resp.data
+    body = resp.data.decode()
+    assert "Uploaded to SV Service" in body
+    assert "hello.txt" in body.split("Uploaded to SV Service", 1)[1]
 
 
 def test_admin_can_upload_selected_files(client, tmp_path, monkeypatch):
@@ -174,7 +178,9 @@ def test_admin_can_upload_selected_files(client, tmp_path, monkeypatch):
     )
     assert resp.status_code == 200
     assert (tmp_path / "remote.txt").exists()
-    assert b"remote.txt" in resp.data
+    body = resp.data.decode()
+    assert "Uploaded to SV Service" in body
+    assert "remote.txt" in body.split("Uploaded to SV Service", 1)[1]
 
 
 def test_student_files_shows_uploaded_list(client, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Store metadata for files admins upload from Moodle, assigning a UUID and owner
- Extend file browser tests to ensure uploaded files appear under "Uploaded to SV Service"

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b99fc6c24832cb233502f4ad5d0e8