### PR TITLE
Handle malformed Moodle responses in get_enrolled_users and add tests

### DIFF
--- a/app/files/blueprint.py
+++ b/app/files/blueprint.py
@@ -561,8 +561,32 @@ def get_enrolled_users(course_id=None):
     if not data:
         return []
 
+    if isinstance(data, dict):
+        current_app.logger.warning(
+            "Expected list from core_enrol_get_enrolled_users for course %s, got dict: %s",
+            course_id,
+            data.get("message", data),
+        )
+        return []
+
+    if not isinstance(data, list):
+        current_app.logger.warning(
+            "Expected list from core_enrol_get_enrolled_users for course %s, got %s",
+            course_id,
+            type(data).__name__,
+        )
+        return []
+
     filtered_users = []
     for u in data:
+        if not isinstance(u, dict):
+            current_app.logger.warning(
+                "Skipping malformed enrolled user entry for course %s: %r",
+                course_id,
+                u,
+            )
+            continue
+
         username = u.get("username", "")
         if username in ["guest", "apiuser"]:
             continue

--- a/tests/test_files_blueprint.py
+++ b/tests/test_files_blueprint.py
@@ -205,3 +205,45 @@ def test_student_files_shows_uploaded_list(client, tmp_path, monkeypatch):
     assert (tmp_path / "loaded.txt").exists()
     assert b"loaded.txt" in resp.data
 
+
+
+def test_get_enrolled_users_handles_error_dict(app, monkeypatch):
+    from app.files import blueprint
+
+    with app.test_request_context():
+        monkeypatch.setattr(
+            blueprint,
+            "moodle_api_call",
+            lambda function, params=None: {
+                "exception": "moodle_exception",
+                "errorcode": "invalidparameter",
+                "message": "Invalid course id",
+            },
+        )
+
+        assert blueprint.get_enrolled_users(course_id=123) == []
+
+
+def test_get_enrolled_users_skips_non_dict_entries(app, monkeypatch):
+    from app.files import blueprint
+
+    with app.test_request_context():
+        monkeypatch.setattr(
+            blueprint,
+            "moodle_api_call",
+            lambda function, params=None: [
+                "bad-entry",
+                {"id": 7, "username": "student1", "fullname": "Student One", "email": "s1@example.com"},
+            ],
+        )
+
+        users = blueprint.get_enrolled_users(course_id=123)
+        assert users == [
+            {
+                "id": 7,
+                "username": "student1",
+                "fullname": "Student One",
+                "email": "s1@example.com",
+                "roles": [],
+            }
+        ]


### PR DESCRIPTION
### Motivation

- The Moodle API call `core_enrol_get_enrolled_users` can sometimes return non-list or error-dict payloads which break downstream code expecting a list of user dicts.  
- The function should be defensive and skip malformed entries while logging useful warnings to aid troubleshooting.  

### Description

- Added type checks in `get_enrolled_users` to detect when the Moodle response is a dict or any non-list and return an empty list while logging a warning via `current_app.logger.warning`.  
- Added validation to skip non-dict entries inside the returned list and log a warning for each skipped item.  
- Preserved existing filtering of guest/API users and mapping of user fields into a sanitized `user_info` dict.  
- Updated tests in `tests/test_files_blueprint.py` to cover the new behavior.  

### Testing

- Added `test_get_enrolled_users_handles_error_dict` which stubs `moodle_api_call` to return an error dict and asserts `get_enrolled_users` returns `[]`; this test passed.  
- Added `test_get_enrolled_users_skips_non_dict_entries` which stubs `moodle_api_call` to return a list containing a non-dict entry and a valid user dict and asserts the malformed entry is skipped; this test passed.  
- Ran the modified test file with `pytest tests/test_files_blueprint.py` and the tests in this file succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34b5d7520832cbd346f1bdafe7bf1)