### PR TITLE
Improve diagnostics when Moodle enrolled-user lookup returns no users

### DIFF
--- a/app/files/blueprint.py
+++ b/app/files/blueprint.py
@@ -549,17 +549,21 @@ def get_user_courses(user_id: int):
         return []
 
 
-def get_enrolled_users(course_id=None):
-    """Return users enrolled in a specific course."""
+def get_enrolled_users(course_id=None, include_error: bool = False):
+    """Return users enrolled in a specific course.
+
+    When include_error=True, returns a tuple: (users, error_message).
+    """
     if not course_id:
         course_id = session.get("context_id")
 
     if not course_id:
-        return []
+        return ([], "Missing course context ID") if include_error else []
 
     data = moodle_api_call("core_enrol_get_enrolled_users", {"courseid": course_id})
     if not data:
-        return []
+        msg = "Moodle API returned no data for enrolled users"
+        return ([], msg) if include_error else []
 
     if isinstance(data, dict):
         current_app.logger.warning(
@@ -567,7 +571,7 @@ def get_enrolled_users(course_id=None):
             course_id,
             data.get("message", data),
         )
-        return []
+        return ([], data.get("message", "Moodle returned an API error")) if include_error else []
 
     if not isinstance(data, list):
         current_app.logger.warning(
@@ -600,7 +604,7 @@ def get_enrolled_users(course_id=None):
         }
         filtered_users.append(user_info)
 
-    return filtered_users
+    return (filtered_users, None) if include_error else filtered_users
 
 
 def get_all_users(limit=200, offset=0):
@@ -1248,7 +1252,7 @@ def file_browser():
             return render_template_string(html, courses=courses, ltik=ltik)
 
         # Get users enrolled in the selected course
-        users = get_enrolled_users(course_id)
+        users, users_error = get_enrolled_users(course_id, include_error=True)
         context_title = session.get("context_title", f"Course {course_id}")
 
         html = """
@@ -1679,6 +1683,15 @@ def file_browser():
             <h1>File Browser</h1>
         </div>
         
+        {% if users_error %}
+        <div class="warning">
+            <div class="warning-icon"></div>
+            <div class="warning-content">
+                <strong>Enrollment API warning:</strong> {{ users_error }}. Check Moodle token permissions and external service function access.
+            </div>
+        </div>
+        {% endif %}
+
         {% if not (base_url and token) %}
         <div class="warning">
             <div class="warning-icon"></div>
@@ -1749,7 +1762,8 @@ def file_browser():
             base_url=base_url,
             token=token,
             context_title=context_title,
-            selected_course=course_id
+            selected_course=course_id,
+            users_error=users_error
         )
 
     # Admin + user selected: show that user's Moodle files and local uploads


### PR DESCRIPTION
### Motivation
- The file browser UI could show “Showing 0 enrolled users” even when learners exist because the Moodle `core_enrol_get_enrolled_users` call may fail or return an error payload. 
- That failure is often due to token permissions, missing external service functions, or a missing course context and was not distinguishable from a true empty enrollment set.
- Expose diagnostic context so admins can triage Moodle-side configuration/permission issues faster from the UI.

### Description
- Change `get_enrolled_users` signature to `get_enrolled_users(course_id=None, include_error: bool = False)` to optionally return a tuple `(users, error_message)` when `include_error=True`.
- Return clearer diagnostic messages for missing course context (`"Missing course context ID"`), empty Moodle responses (`"Moodle API returned no data for enrolled users"`), and when Moodle returns an error dict (use its `message`).
- Update the file-browser flow to call `get_enrolled_users(..., include_error=True)` and pass `users_error` into the template render context.
- Add an in-page banner — `Enrollment API warning` — that displays `users_error` for admins so configuration/permission problems are visible instead of silently showing zero users.

### Testing
- Ran `pytest -q tests/test_files_blueprint.py::test_get_enrolled_users_handles_error_dict` and `pytest -q tests/test_files_blueprint.py::test_get_enrolled_users_skips_non_dict_entries` and both tests passed (2 passed, with unrelated warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f351f3ca74832c8d4113f91c24cd10)